### PR TITLE
Fix the case for the DLL

### DIFF
--- a/PowerShellHumanizer.psm1
+++ b/PowerShellHumanizer.psm1
@@ -1,4 +1,4 @@
-Add-Type -Path "$PSScriptRoot\humanizer.dll"
+Add-Type -Path "$PSScriptRoot\Humanizer.dll"
 
 $Types = @("$PSScriptRoot\String.types.ps1xml", 
     "$PSScriptRoot\Int.types.ps1xml", 


### PR DESCRIPTION
On Linux with a case sensitive file system, the first line fails because the actuall `dll` has `h` as uppercase: `Humanizer.dll`